### PR TITLE
fix: use batch embedding via embed_documents() for vector DB creation (#8)

### DIFF
--- a/src/medical_workflow/nodes/rag.py
+++ b/src/medical_workflow/nodes/rag.py
@@ -15,6 +15,10 @@ def build_medical_vector_db(file_path: str, persist_dir: str | None = None):
 
     - persist_dir가 존재하고 DB가 이미 있으면 → 즉시 로드
     - 없으면 CSV 기반으로 생성 후 디스크에 저장
+
+    배치 임베딩 최적화:
+    - embed_documents()로 전체 텍스트를 한 번에 임베딩하여 API 호출 오버헤드 감소
+    - from_embeddings()로 사전 계산된 벡터를 사용하여 DB 생성
     """
 
     embeddings = UpstageEmbeddings(model="solar-embedding-1-large")
@@ -53,11 +57,20 @@ def build_medical_vector_db(file_path: str, persist_dir: str | None = None):
         axis=1,
     )
 
-    vector_db = Chroma.from_texts(
-        texts=df["combined_text"].tolist(),
+    texts = df["combined_text"].tolist()
+
+    # 배치 임베딩: embed_documents()로 전체 텍스트를 한 번에 처리
+    # from_texts()는 내부적으로 순차 임베딩을 수행하여 ~1800건에서 5분 이상 소요
+    # embed_documents()는 배치 처리로 API 호출 횟수를 대폭 줄여 성능 향상
+    print(f"[VectorDB] {len(texts)}건 배치 임베딩 시작...")
+    vectors = embeddings.embed_documents(texts)
+    print(f"[VectorDB] 배치 임베딩 완료, DB 생성 중...")
+
+    vector_db = Chroma.from_embeddings(
+        text_embeddings=list(zip(texts, vectors)),
         embedding=embeddings,
         collection_name="medical_info",
-        persist_directory=persist_dir,  # 🔥 핵심 추가
+        persist_directory=persist_dir,
     )
 
     # 명시적 persist (안전)

--- a/tests/test_rag_batch_embedding.py
+++ b/tests/test_rag_batch_embedding.py
@@ -1,0 +1,98 @@
+"""test_rag_batch_embedding.py
+
+Unit tests for the batch embedding optimization in build_medical_vector_db().
+Verifies that embed_documents() is called once with all texts (batch)
+instead of multiple sequential embed_query() calls.
+"""
+
+import os
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+
+
+def _make_csv(tmp_path: str) -> str:
+    """Create a minimal medical CSV for testing."""
+    csv_path = os.path.join(tmp_path, "medical.csv")
+    df = pd.DataFrame(
+        {
+            "병명": ["감기", "두통", "소화불량"],
+            "생활가이드": ["휴식을 취하세요", "조용한 곳에서 쉬세요", "소화제를 복용하세요"],
+            "식이요법/생활가이드": ["따뜻한 물을 마시세요", "카페인을 피하세요", "기름진 음식을 피하세요"],
+        }
+    )
+    df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+    return csv_path
+
+
+@patch("medical_workflow.nodes.rag.UpstageEmbeddings")
+@patch("medical_workflow.nodes.rag.Chroma")
+def test_batch_embedding_used(mock_chroma_cls, mock_embeddings_cls):
+    """build_medical_vector_db should use embed_documents() for batch embedding."""
+    mock_embeddings = MagicMock()
+    mock_embeddings_cls.return_value = mock_embeddings
+
+    # embed_documents returns a list of vectors (one per text)
+    fake_vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+    mock_embeddings.embed_documents.return_value = fake_vectors
+
+    mock_db = MagicMock()
+    mock_chroma_cls.from_embeddings.return_value = mock_db
+
+    with tempfile.TemporaryDirectory() as tmp:
+        csv_path = _make_csv(tmp)
+        persist_dir = os.path.join(tmp, "chroma_db")
+        os.makedirs(persist_dir)
+
+        from medical_workflow.nodes.rag import build_medical_vector_db
+
+        result = build_medical_vector_db(file_path=csv_path, persist_dir=persist_dir)
+
+    # Key assertion: embed_documents called ONCE with all texts (batch)
+    mock_embeddings.embed_documents.assert_called_once()
+    call_args = mock_embeddings.embed_documents.call_args[0][0]
+    assert len(call_args) == 3, f"Expected 3 texts, got {len(call_args)}"
+    assert "감기" in call_args[0]
+
+    # Verify from_embeddings was used (not from_texts)
+    mock_chroma_cls.from_embeddings.assert_called_once()
+    mock_chroma_cls.from_texts.assert_not_called()
+
+    # Verify text_embeddings format: list of (text, vector) tuples
+    te_arg = mock_chroma_cls.from_embeddings.call_args[1]["text_embeddings"]
+    assert len(te_arg) == 3
+    assert te_arg[0] == (call_args[0], fake_vectors[0])
+
+    assert result is mock_db
+
+
+@patch("medical_workflow.nodes.rag.UpstageEmbeddings")
+@patch("medical_workflow.nodes.rag.Chroma")
+def test_persisted_db_loads_without_embedding(mock_chroma_cls, mock_embeddings_cls):
+    """When persist_dir has existing data, no embedding calls should be made."""
+    mock_embeddings = MagicMock()
+    mock_embeddings_cls.return_value = mock_embeddings
+
+    mock_db = MagicMock()
+    mock_chroma_cls.return_value = mock_db
+
+    with tempfile.TemporaryDirectory() as tmp:
+        persist_dir = os.path.join(tmp, "chroma_db")
+        os.makedirs(persist_dir)
+        # Write a dummy file so os.listdir() is non-empty
+        with open(os.path.join(persist_dir, "test"), "w") as f:
+            f.write("data")
+
+        from medical_workflow.nodes.rag import build_medical_vector_db
+
+        result = build_medical_vector_db(file_path="unused.csv", persist_dir=persist_dir)
+
+    # No embedding calls should be made
+    mock_embeddings.embed_documents.assert_not_called()
+    mock_embeddings.embed_query.assert_not_called()
+
+    # Chroma should be constructed directly (not from_texts or from_embeddings)
+    mock_chroma_cls.assert_called_once()
+    assert result is mock_db


### PR DESCRIPTION
## Summary

Replace `Chroma.from_texts()` with `embed_documents()` + `Chroma.from_embeddings()` to batch all text embeddings in a single API call instead of sequential calls.

## Problem

`build_medical_vector_db()` uses `Chroma.from_texts()` which internally calls the embedding function sequentially for each text. With ~1800 medical records, this causes:
- 5+ minute build times on first run
- Unnecessary sequential API calls to the embedding service
- Higher cost from repeated API round-trips

## Solution

1. **Pre-compute all embeddings in one batch** using `embeddings.embed_documents(texts)` — this processes all texts in a single API call
2. **Use `Chroma.from_embeddings()`** with the pre-computed vectors to create the DB

The persist/cached-load path (already implemented) is unchanged — when a persisted DB exists, it loads directly without any embedding calls.

## Verification

```bash
PYTHONPATH=src .venv/bin/python -m pytest tests/test_rag_batch_embedding.py -v
```

```
tests/test_rag_batch_embedding.py::test_batch_embedding_used PASSED
tests/test_rag_batch_embedding.py::test_persisted_db_loads_without_embedding PASSED
2 passed
```

**Tests verify:**
- `embed_documents()` is called exactly once with all texts (batch behavior)
- `from_embeddings()` is used instead of `from_texts()`
- `text_embeddings` format is correct `(text, vector)` pairs
- When persisted DB exists, no embedding calls are made at all

Closes #8

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
